### PR TITLE
♻️ Use wuchale instead of ad-hoc i18n middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ media
 test-results/
 .netlify/
 src/pages/shs/pomi-documents.zip
+
+i18n/*
+!i18n/*.po

--- a/astro.config.mts
+++ b/astro.config.mts
@@ -2,6 +2,7 @@
 import mdx from "@astrojs/mdx";
 import netlify from "@astrojs/netlify";
 import sitemap from "@astrojs/sitemap";
+import { wuchale } from "@wuchale/vite-plugin";
 import { defineConfig } from "astro/config";
 import type { InferEntrySchema } from "astro:content";
 import { readFileSync } from "node:fs";
@@ -24,6 +25,19 @@ export default defineConfig({
       filter: (url) => !new URL(url).pathname.startsWith("/works/"),
     }),
   ],
+
+  vite: {
+    plugins: [wuchale()],
+  },
+
+  i18n: {
+    locales: ["en", "fr"],
+    defaultLocale: "en",
+    routing: {
+      prefixDefaultLocale: true,
+      redirectToDefaultLocale: true,
+    },
+  },
 
   site: `https://${process.env.LANG}.gwen.works`,
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,8 @@
         "@astrojs/netlify": "^6.5.13",
         "@astrojs/rss": "^4.0.12",
         "@astrojs/sitemap": "^3.6.0",
+        "@wuchale/astro": "^0.2.4",
+        "@wuchale/vite-plugin": "^0.16.2",
         "astro": "^5.14.6",
         "date-fns": "^4.1.0",
         "jsdom": "^28.1.0",
@@ -16,6 +18,7 @@
         "pofile": "^1.1.4",
         "slug": "^11.0.1",
         "tinycolor2": "^1.6.0",
+        "wuchale": "^0.19.2",
         "yaml": "^2.8.2",
       },
       "devDependencies": {
@@ -626,6 +629,10 @@
     "@whatwg-node/promise-helpers": ["@whatwg-node/promise-helpers@1.3.2", "", { "dependencies": { "tslib": "^2.6.3" } }, "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA=="],
 
     "@whatwg-node/server": ["@whatwg-node/server@0.10.12", "", { "dependencies": { "@envelop/instrumentation": "^1.0.0", "@whatwg-node/disposablestack": "^0.0.6", "@whatwg-node/fetch": "^0.10.10", "@whatwg-node/promise-helpers": "^1.3.2", "tslib": "^2.6.3" } }, "sha512-MQIvvQyPvKGna586MzXhgwnEbGtbm7QtOgJ/KPd/tC70M/jbhd1xHdIQQbh3okBw+MrDF/EvaC2vB5oRC7QdlQ=="],
+
+    "@wuchale/astro": ["@wuchale/astro@0.2.8", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@sveltejs/acorn-typescript": "^1.0.9", "acorn": "^8.15.0", "magic-string": "^0.30.21", "wuchale": "^0.20.0" } }, "sha512-QMbwymVLEU+F6+KcsW8Kh1iEjHtqZrCUgSXzkDYxkbKK/qOLZO3s6iKTIyROksQAFjC5ZtqyiC3UtfGIORDfFg=="],
+
+    "@wuchale/vite-plugin": ["@wuchale/vite-plugin@0.16.2", "", { "dependencies": { "wuchale": "^0.19.0" } }, "sha512-ejTqoJew7F+zOQ8IDYa+PNPiD+YTV/9p0LpIqnoOM6s5sVVzHvuskGVNUVprVmMsWGVRSQDt0qX6mifi9ufutg=="],
 
     "@xhmikosr/archive-type": ["@xhmikosr/archive-type@6.0.1", "", { "dependencies": { "file-type": "^18.5.0" } }, "sha512-PB3NeJL8xARZt52yDBupK0dNPn8uIVQDe15qNehUpoeeLWCZyAOam4vGXnoZGz2N9D1VXtjievJuCsXam2TmbQ=="],
 
@@ -1513,7 +1520,7 @@
 
     "macos-release": ["macos-release@3.4.0", "", {}, "sha512-wpGPwyg/xrSp4H4Db4xYSeAr6+cFQGHfspHzDUdYxswDnUW0L5Ov63UuJiSr8NMSpyaChO4u1n0MXUvVPtrN6A=="],
 
-    "magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
 
@@ -2409,6 +2416,8 @@
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
+    "wuchale": ["wuchale@0.19.4", "", { "dependencies": { "@sveltejs/acorn-typescript": "^1.0.8", "acorn": "^8.15.0", "chokidar": "^5.0.0", "magic-string": "^0.30.21", "path-to-regexp": "^8.3.0", "picomatch": "^4.0.3", "pofile": "^1.1.4", "tinyglobby": "^0.2.15" }, "bin": { "wuchale": "dist/cli/index.js" } }, "sha512-CelGkC//kO1vEo7HT8tF7/TxC6PALYLsgsN963QW/Xrk/VkngcguiviFZAe6Z/nIBtZtevkFCtKqKYz2NOAQ8g=="],
+
     "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
@@ -2585,7 +2594,15 @@
 
     "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
+    "@vue/compiler-sfc/magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
+
     "@whatwg-node/fetch/urlpattern-polyfill": ["urlpattern-polyfill@10.1.0", "", {}, "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="],
+
+    "@wuchale/astro/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
+
+    "@wuchale/astro/wuchale": ["wuchale@0.20.0", "", { "dependencies": { "@sveltejs/acorn-typescript": "^1.0.9", "acorn": "^8.15.0", "chokidar": "^5.0.0", "magic-string": "^0.30.21", "path-to-regexp": "^8.3.0", "picomatch": "^4.0.3", "pofile": "^1.1.4", "tinyglobby": "^0.2.15" }, "bin": { "wuchale": "dist/cli/index.js" } }, "sha512-SdGsKsyYrxdIkqa1Jud8MNrDa/3ZDncnm2fsTBc18VrfOsR04jFJDYVQeTLfHKOZtFxlhZcpWMXBEG82SVpcGQ=="],
+
+    "@wuchale/vite-plugin/wuchale": ["wuchale@0.19.1", "", { "dependencies": { "@sveltejs/acorn-typescript": "^1.0.8", "acorn": "^8.15.0", "chokidar": "^5.0.0", "magic-string": "^0.30.21", "path-to-regexp": "^8.3.0", "picomatch": "^4.0.3", "pofile": "^1.1.4", "tinyglobby": "^0.2.15" }, "bin": { "wuchale": "dist/cli/index.js" } }, "sha512-8Pm/8GFMeOWZWR20PUbbVJHtz14NpOOC2CcXAxALNinY0m8++FdKpH3bSJ+H3O9f8gxDjv0ZOvuAeng6bgx+MA=="],
 
     "@xhmikosr/decompress-tar/is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
 
@@ -2834,6 +2851,8 @@
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "wuchale/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "xss/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
@@ -3115,6 +3134,10 @@
 
     "@vercel/nft/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
+    "@wuchale/astro/wuchale/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "@wuchale/vite-plugin/wuchale/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
     "@xhmikosr/downloader/p-event/p-timeout": ["p-timeout@5.1.0", "", {}, "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="],
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -3269,6 +3292,8 @@
 
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
+    "wuchale/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "zip-stream/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
@@ -3418,6 +3443,10 @@
     "@so-ric/colorspace/color/color-convert/color-name": ["color-name@2.0.2", "", {}, "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A=="],
 
     "@so-ric/colorspace/color/color-string/color-name": ["color-name@2.0.2", "", {}, "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A=="],
+
+    "@wuchale/astro/wuchale/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "@wuchale/vite-plugin/wuchale/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "better-ajv-errors/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@astrojs/netlify": "^6.5.13",
     "@astrojs/rss": "^4.0.12",
     "@astrojs/sitemap": "^3.6.0",
-    "@wuchale/astro": "^0.2.2",
+    "@wuchale/astro": "^0.2.4",
     "@wuchale/vite-plugin": "^0.16.2",
     "astro": "^5.14.6",
     "date-fns": "^4.1.0",
@@ -32,7 +32,7 @@
     "pofile": "^1.1.4",
     "slug": "^11.0.1",
     "tinycolor2": "^1.6.0",
-    "wuchale": "^0.19.1",
+    "wuchale": "^0.19.2",
     "yaml": "^2.8.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev --port 5173",
+    "prebuild": "wuchale --clean --sync -l verbose",
     "build": "astro build",
     "preview": "sirv dist/ --port 4173",
     "astro": "astro",
@@ -22,6 +23,8 @@
     "@astrojs/netlify": "^6.5.13",
     "@astrojs/rss": "^4.0.12",
     "@astrojs/sitemap": "^3.6.0",
+    "@wuchale/astro": "^0.2.2",
+    "@wuchale/vite-plugin": "^0.16.2",
     "astro": "^5.14.6",
     "date-fns": "^4.1.0",
     "jsdom": "^28.1.0",
@@ -29,6 +32,7 @@
     "pofile": "^1.1.4",
     "slug": "^11.0.1",
     "tinycolor2": "^1.6.0",
+    "wuchale": "^0.19.1",
     "yaml": "^2.8.2"
   },
   "devDependencies": {

--- a/src/astro-jsx.ts
+++ b/src/astro-jsx.ts
@@ -1,5 +1,0 @@
-declare namespace astroHTML.JSX {
-  export interface HTMLAttributes {
-    i18n?: boolean;
-  }
-}

--- a/src/components/StrongHeader.astro
+++ b/src/components/StrongHeader.astro
@@ -39,7 +39,7 @@ const { title, wip, back, editButton, editFolderButton } = Astro.props;
             href={back}
             onclick="if (history.length > 1) { event.preventDefault(); history.back(); }"
           >
-            &lt;- <i18n>back</i18n>
+            &lt;- back
           </a>
         )}
         {editButton && (
@@ -66,7 +66,7 @@ const { title, wip, back, editButton, editFolderButton } = Astro.props;
 
   {
     typeof title === "string" ? (
-      <h1 i18n>{title}</h1>
+      <h1>{title}</h1>
     ) : "img" in title ? (
       <h1 class="image">
         <img {...title.img} />

--- a/src/components/WorksGrid.astro
+++ b/src/components/WorksGrid.astro
@@ -136,11 +136,7 @@ function findThumbnailBlock(
                             />
                             {wip && <WIPIndicator />}
                           </h2>
-                          {tagline && (
-                            <span class="tagline" i18n>
-                              {tagline}
-                            </span>
-                          )}
+                          {tagline && <span class="tagline">{tagline}</span>}
                         </section>
                       </article>
                     </a>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,11 +1,10 @@
 import { file, glob } from "astro/loaders";
-import type { ZodNullable, ZodObject, ZodRawShape, ZodString } from "astro/zod";
+import type { ZodObject, ZodRawShape } from "astro/zod";
 import { defineCollection, reference, z } from "astro:content";
-import * as YAML from "yaml";
-import PO from "pofile";
-import { wakatimeCollection } from "./wakatime";
 import { readFile } from "node:fs/promises";
 import slug from "slug";
+import * as YAML from "yaml";
+import { wakatimeCollection } from "./wakatime";
 
 const translatedString = z.object({
   en: z.string(),
@@ -21,8 +20,6 @@ const nullableDate = z
 const year = z.number().min(2003).max(new Date().getFullYear()).int();
 
 export const collections = {
-  frenchMessages: gettextPoMessages("i18n/fr.po"),
-  englishMessages: gettextPoMessages("i18n/en.po"),
   wakatimeLanguages: await wakatimeCollection(
     ".wakatime-cache.json",
     "languages",
@@ -364,25 +361,5 @@ function yamlDataCollection<
         }
       },
     },
-  });
-}
-
-function gettextPoMessages(filename: string) {
-  return defineCollection({
-    schema: z.object({
-      msgid: z.string(),
-      msgstr: z.string(),
-      msgctxt: z.string().optional(),
-    }),
-    loader: file(filename, {
-      parser(text) {
-        return PO.parse(text).items.map((item) => ({
-          id: item.msgid,
-          ...item,
-          msgstr: item.msgstr[0],
-          msgctxt: item.msgctxt || undefined,
-        }));
-      },
-    }),
   });
 }

--- a/src/layouts/Bare.astro
+++ b/src/layouts/Bare.astro
@@ -59,4 +59,8 @@ interface Props {
     height: calc(100% - 2 * var(--pad));
     gap: 2rem;
   }
+
+  :is(h1, h2, h3, h4, h5, h6, p, span, li, a, pre):not(.no-lowercase) {
+    text-transform: lowercase;
+  }
 </style>

--- a/src/layouts/Regular.astro
+++ b/src/layouts/Regular.astro
@@ -1,5 +1,4 @@
 ---
-import YAML from "yaml";
 import { getCollection } from "astro:content";
 import Bare from "./Bare.astro";
 import { setCssColors } from "../colors";

--- a/src/pages/blog/[entry].astro
+++ b/src/pages/blog/[entry].astro
@@ -31,7 +31,7 @@ const dateFormatter = new Intl.DateTimeFormat(Astro.locals.locale, {
     editButton={`~/projects.local/portfolio/blog/${Astro.params.entry}.md`}
   >
     <p class="intro">
-      <span i18n>published on</span>
+      <span>published on</span>
       <time datetime={date.toISOString()}>
         {dateFormatter.format(date)}
       </time>
@@ -41,7 +41,7 @@ const dateFormatter = new Intl.DateTimeFormat(Astro.locals.locale, {
   <main set:html={rendered!.html} />
 
   <section class="related">
-    <h2 i18n>related works</h2>
+    <h2>related works</h2>
     {
       await getEntries(works).then((entries) => (
         <WorksGrid works={entries.filter(Boolean).map((e) => e.data)} />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -31,7 +31,7 @@ const dateFormatter = new Intl.DateTimeFormat(Astro.locals.locale, {
     </ul>
 
     <section class="drafts">
-      <h2 i18n>(drafts)</h2>
+      <h2>(drafts)</h2>
       <ul>
         {
           posts

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -9,13 +9,13 @@ const insta = await getEntry("sites", "instagram");
 
 <Layout>
   <StrongHeader title="Contact me">
-    <p i18n>via...</p>
+    <p>via...</p>
     <dl>
       <dt>email</dt>
       <dd>
-        <a i18n href="/to/mail">gwenn.lebihan7 (at-sign) gmail.com</a>
+        <a href="/to/mail">gwenn.lebihan7 (at-sign) gmail.com</a>
       </dd>
-      <dt i18n>bluesky direct message</dt>
+      <dt>bluesky direct message</dt>
       <dd>
         <a href="/to/bluesky">@{bsky?.data.username}</a>
       </dd>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,9 +15,9 @@ const smolWorks = (await getEntry("collections", "smol"))?.data?.includes.split(
   <div class="header-with-logo">
     <Logo slot="title-pre" />
     <StrongHeader title="Hiya!">
-      <p i18n>I'm Gwenn Le Bihan :3</p>
-      <p i18n>interested in anything that touches art, technology or both</p>
-      <a href="/resume">-&gt; <i18n>resume</i18n></a>
+      <p>I'm Gwenn Le Bihan :3</p>
+      <p>interested in anything that touches art, technology or both</p>
+      <a href="/resume">-&gt; resume</a>
       <nav class="webring">
         <a href="https://n7webring.neocities.org/gwenn/prev">&lt;-</a>
         <a href="https://n7webring.neocities.org">n7webring</a>

--- a/src/pages/resume/index.astro
+++ b/src/pages/resume/index.astro
@@ -51,7 +51,7 @@ const experience = await getCollection("experiences").then((entries) =>
 >
   <header>
     <h1>Gwenn Le Bihan</h1>
-    <p class="intro" i18n>
+    <p class="intro">
       I am interested in almost anything that is both creative &amp; digital.
     </p>
     <dl>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -38,10 +38,10 @@ const works = await getCollection("works").then((works) =>
     editButton="~/projects.local/portfolio/tags.yaml"
   >
     <section class="description">
-      <div i18n class="description" set:html={entry.rendered!.html} />
+      <div class="description" set:html={entry.rendered!.html} />
       {
         learnMoreAt && (
-          <a href={learnMoreAt} class="learn-more" i18n>
+          <a href={learnMoreAt} class="learn-more">
             learn more
           </a>
         )

--- a/src/pages/using/[tech].astro
+++ b/src/pages/using/[tech].astro
@@ -51,12 +51,10 @@ const name = tech.data.name === "C Sharp" ? "C#" : tech.data.name;
     title={name}
     editButton="~/projects.local/portfolio/technologies.yaml"
   >
-    <div class="description" i18n set:html={tech.rendered!.html} />
+    <div class="description" set:html={tech.rendered!.html} />
     {
       tech.data["learn more at"] && (
-        <a i18n href={tech.data["learn more at"]}>
-          learn more
-        </a>
+        <a href={tech.data["learn more at"]}>learn more</a>
       )
     }
   </StrongHeader>

--- a/src/pages/works/[work].astro
+++ b/src/pages/works/[work].astro
@@ -184,7 +184,7 @@ const folderPath = entry.data.source.split("\\").slice(0, -2).join("\\");
   {
     hoursSpent > 1 ? (
       <section class="big">
-        <h2 i18n>time spent*</h2>
+        <h2>time spent*</h2>
         <p>
           {timeSpent.length === 1 && timeSpent.at(0)?.url ? (
             <a
@@ -216,7 +216,7 @@ const folderPath = entry.data.source.split("\\").slice(0, -2).join("\\");
         ) : null}
         <small>
           <br />
-          <i18n>*tracked by</i18n>
+          *tracked by
           <a href="https://wakatime.com/" target="_blank">
             WakaTime
           </a>
@@ -228,7 +228,7 @@ const folderPath = entry.data.source.split("\\").slice(0, -2).join("\\");
   {
     madeWith && madeWith.length > 0 && (
       <section class="big">
-        <h2 i18n>made with</h2>
+        <h2>made with</h2>
         <ul class="technologies">
           {madeWith.map(({ id, data: { name } }) => (
             <li>
@@ -243,7 +243,7 @@ const folderPath = entry.data.source.split("\\").slice(0, -2).join("\\");
   {
     Object.keys(footnotes).length ? (
       <section class="footnotes">
-        <h2 i18n>footnotes</h2>
+        <h2>footnotes</h2>
         <ul>
           {Object.entries(footnotes).map(([id, content]) => (
             <li id={`fn:${id}`}>

--- a/works.json
+++ b/works.json
@@ -41145,7 +41145,7 @@
   },
   "swarpc": {
     "Partial": false,
-    "builtAt": "2025-11-17T14:05:18.9151622+01:00",
+    "builtAt": "2026-02-06T12:25:17.388345+01:00",
     "content": {
       "en": {
         "abbreviations": {},
@@ -41503,7 +41503,7 @@
             "duration": 0,
             "hasSound": false,
             "hash": "",
-            "id": "aW0pE7jpbZ",
+            "id": "2Md6co44rW",
             "index": 0,
             "online": false,
             "relativeSource": "",
@@ -41513,7 +41513,7 @@
             "thumbnailsBuiltAt": "0001-01-01T00:00:00Z",
             "title": "",
             "type": "link",
-            "url": "https://gwennlbh.github.io/swarpc/docs"
+            "url": "https://swarpc.js.org"
           },
           {
             "alt": "",
@@ -41606,8 +41606,8 @@
           [
             "hCXsc0viQI",
             "hCXsc0viQI",
-            "aW0pE7jpbZ",
-            "aW0pE7jpbZ",
+            "2Md6co44rW",
+            "2Md6co44rW",
             "eScdvIhsPg",
             "eScdvIhsPg"
           ]
@@ -41970,7 +41970,7 @@
             "duration": 0,
             "hasSound": false,
             "hash": "",
-            "id": "aW0pE7jpbZ",
+            "id": "2Md6co44rW",
             "index": 0,
             "online": false,
             "relativeSource": "",
@@ -41980,7 +41980,7 @@
             "thumbnailsBuiltAt": "0001-01-01T00:00:00Z",
             "title": "",
             "type": "link",
-            "url": "https://gwennlbh.github.io/swarpc/docs"
+            "url": "https://swarpc.js.org"
           },
           {
             "alt": "",
@@ -42073,8 +42073,8 @@
           [
             "hCXsc0viQI",
             "hCXsc0viQI",
-            "aW0pE7jpbZ",
-            "aW0pE7jpbZ",
+            "2Md6co44rW",
+            "2Md6co44rW",
             "eScdvIhsPg",
             "eScdvIhsPg"
           ]
@@ -42082,7 +42082,7 @@
         "title": "swarpc"
       }
     },
-    "descriptionHash": "ecJwmUeoxAmXrE5ESU8wiw==",
+    "descriptionHash": "3VGpEgydDnZT1wazHwszGQ==",
     "id": "swarpc",
     "metadata": {
       "additionalMetadata": {

--- a/wuchale.config.js
+++ b/wuchale.config.js
@@ -1,0 +1,12 @@
+// @ts-check
+import { adapter as astro } from "@wuchale/astro";
+import { defineConfig } from "wuchale";
+
+export default defineConfig({
+  locales: ["en", "fr"],
+  adapters: {
+    main: astro({
+      localesDir: "i18n",
+    }),
+  },
+});


### PR DESCRIPTION
TODO

- [ ] Fix errors during extraction of src/layouts/Regular.astro: https://discord.com/channels/1399758252383797318/1457534652511162428 / maybe try again once Astro is upgraded to latest ver. lmao
- [ ] lowercase stuff via CSS since wuchale requires title case for extractable detection. _or_ maybe keep the i18n attr/tags, use that as a custom Wuchale heuristic. We still benefit from Wuchale upkeeping the .po files by itself instead of having to manually add/remove stuff (which i never bothered to do lmao)
- [ ] knip out deps. we can probably remove jsdom, the po parsing library and maybe others
- [ ] some things we translated "post-rendering", such as `<span i18n>{tagline}</span>` for example. figure out what to do there